### PR TITLE
Fixed compilation issue in Java 1.8+

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -137,6 +137,25 @@
 			</plugin>
 		</plugins>
 	</build>
+	<profiles>
+		<profile>
+			<id>doclint-java8-disable</id>
+			<activation>
+				<jdk>[1.8,)</jdk>
+			</activation>
+		<build>
+			<plugins>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-javadoc-plugin</artifactId>
+					<configuration>
+						<additionalparam>-Xdoclint:none</additionalparam>
+					</configuration>
+				</plugin>
+			</plugins>
+		</build>
+		</profile>
+	</profiles>
 
 	<distributionManagement>
 		<repository>


### PR DESCRIPTION
Starting with Java 1.8+ Oracle has added a lint feature to the Javadocs that checks them for correctness and fails with a compiler error if they are not correct.  There are several issues with the Javadocs for this project so the easiest fix is to turn off the lint checking, which adds very little.  To do this I added a profile that just fires off for Java 1.8+ and all it does is turn off the lint checking.
