### PR TITLE
Add DeploymentName parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,13 @@ In order to post to the Mule Repository, you need only these permissions:
 		MuleApplication
 <tr>
 	<td>
+		deploymentName
+	<td>
+		What to name the deployment when it is uploaded to the repository
+	<td>
+		same as <code>name</code>
+<tr>
+	<td>
 		version
 	<td>
 		What version to give the software when it is uploaded to the repository

--- a/src/main/java/org/mule/tools/maven/rest/Deploy.java
+++ b/src/main/java/org/mule/tools/maven/rest/Deploy.java
@@ -49,6 +49,14 @@ public class Deploy extends AbstractMojo {
     protected String name;
 
     /**
+     * The name that the application will be deployed as. Default is
+     * same as ${name}
+     *
+     * @parameter expression="${deploymentName}"
+     */
+    protected String deploymentName;
+
+    /**
      * The version that the application will be deployed as. Default is the
      * current time in milliseconds.
      * 
@@ -102,6 +110,10 @@ public class Deploy extends AbstractMojo {
 	    logger.info("Name is not set, using default \"{}\"", DEFAULT_NAME);
 	    name = DEFAULT_NAME;
 	}
+	if (deploymentName == null) {
+	    logger.info("DeploymentName is not set, using application name \"{}\"", name);
+	    deploymentName = name;
+	}
 	if (version == null) {
 	    version = new SimpleDateFormat("MM-dd-yyyy-HH:mm:ss").format(Calendar.getInstance()
 		    .getTime());
@@ -123,7 +135,7 @@ public class Deploy extends AbstractMojo {
 	    validateProject(appDirectory);
 	    muleRest = buildMuleRest();
 	    String versionId = muleRest.restfullyUploadRepository(name, version, getMuleZipFile(outputDirectory, finalName));
-	    String deploymentId = muleRest.restfullyCreateDeployment(serverGroup, name, versionId);
+	    String deploymentId = muleRest.restfullyCreateDeployment(serverGroup, deploymentName, versionId);
 	    muleRest.restfullyDeployDeploymentById(deploymentId);
 	} catch (Exception e) {
 	    throw new MojoFailureException("Error in attempting to deploy archive: " + e.toString(), e);

--- a/src/test/java/org/mule/tools/maven/rest/DeployTest.java
+++ b/src/test/java/org/mule/tools/maven/rest/DeployTest.java
@@ -83,10 +83,17 @@ public class DeployTest {
     }
 
     @Test(expected = MojoFailureException.class)
-    public void testServerGRoupNull() throws MojoExecutionException, MojoFailureException {
+    public void testServerGroupNull() throws MojoExecutionException, MojoFailureException {
 	deploy.serverGroup = null;
 	deploy.execute();
 	Assert.fail("Exception should have been thrown before this is called");
+    }
+
+    @Test
+    public void testDeploymentNameNull() throws MojoExecutionException, MojoFailureException {
+        deploy.deploymentName = null;
+        deploy.execute();
+        Assert.assertEquals("When null, deploymentName should be same as name", deploy.name, deploy.deploymentName);
     }
     
     @Test


### PR DESCRIPTION
In many use-cases it is useful to have separate names for the deployment and application upload.  
Adding the optional <code>deploymentName</code> parameter (which defaults to <code>name</code>) allows this to be configured if desired.