### PR TITLE
Added support to deploy apps to cluster

### DIFF
--- a/src/main/java/org/mule/tools/maven/rest/Deploy.java
+++ b/src/main/java/org/mule/tools/maven/rest/Deploy.java
@@ -97,8 +97,14 @@ public class Deploy extends AbstractMojo {
      * @required
      */
     protected String serverGroup;
-    
-    protected MuleRest muleRest;
+
+	/**
+	 * @parameter expression="${clusterName}"
+	 */
+	protected String clusterName;
+
+
+	protected MuleRest muleRest;
 
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
@@ -131,11 +137,12 @@ public class Deploy extends AbstractMojo {
 	if (serverGroup == null) {
 	    throw new MojoFailureException("serverGroup not set.");
 	}
+
 	try {
 	    validateProject(appDirectory);
 	    muleRest = buildMuleRest();
 	    String versionId = muleRest.restfullyUploadRepository(name, version, getMuleZipFile(outputDirectory, finalName));
-	    String deploymentId = muleRest.restfullyCreateDeployment(serverGroup, deploymentName, versionId);
+	    String deploymentId = muleRest.restfullyCreateDeployment(serverGroup, deploymentName, clusterName, versionId);
 	    muleRest.restfullyDeployDeploymentById(deploymentId);
 	} catch (Exception e) {
 	    throw new MojoFailureException("Error in attempting to deploy archive: " + e.toString(), e);

--- a/src/test/java/org/mule/tools/maven/rest/DeployTest.java
+++ b/src/test/java/org/mule/tools/maven/rest/DeployTest.java
@@ -21,7 +21,8 @@ public class DeployTest {
 	private static final String SERVER_GROUP = "Development";
 	private static final String NAME = "MyMuleApp";
 	private static final String VERSION = "1.0-SNAPSHOT";
-	
+	private static final String CLUSTER_NAME = null;
+
     private Deploy deploy;
     
     private MuleRest mockMuleRest;
@@ -51,7 +52,7 @@ public class DeployTest {
 	mockMuleRest = mock(MuleRest.class);
 	when(deploy.buildMuleRest()).thenReturn(mockMuleRest);
 	when(mockMuleRest.restfullyUploadRepository(anyString(), anyString(), any(File.class))).thenReturn(VERSION_ID);
-	when(mockMuleRest.restfullyCreateDeployment(anyString(), anyString(), anyString())).thenReturn(DEPLOYMENT_ID);
+	when(mockMuleRest.restfullyCreateDeployment(anyString(), anyString(), null, anyString())).thenReturn(DEPLOYMENT_ID);
     }
 
     @Test(expected = MojoFailureException.class)
@@ -100,7 +101,7 @@ public class DeployTest {
     public void testHappyPath() throws Exception{
 	deploy.execute();
 	verify(mockMuleRest).restfullyUploadRepository(NAME, VERSION, null);
-	verify(mockMuleRest).restfullyCreateDeployment(SERVER_GROUP, NAME, VERSION_ID);
+	verify(mockMuleRest).restfullyCreateDeployment(SERVER_GROUP, NAME, CLUSTER_NAME, VERSION_ID);
 	verify(mockMuleRest).restfullyDeployDeploymentById(DEPLOYMENT_ID);
     }
 }

--- a/src/test/java/org/mule/tools/maven/rest/MuleRestTest.java
+++ b/src/test/java/org/mule/tools/maven/rest/MuleRestTest.java
@@ -276,7 +276,7 @@ public class MuleRestTest {
 	stubCreateDeployment(deploymentId);
 	stubGetDeploymentIdByName(name, deploymentId);
 	stubDeleteDeploymentById(deploymentId);
-	muleRest.restfullyCreateDeployment(serverGroup, name, versionId);
+	muleRest.restfullyCreateDeployment(serverGroup, name, null, versionId);
 	verifyDeleteDeploymentById(deploymentId);
 	verifyGetDeploymentIdByName();
 	verifyGetServers();


### PR DESCRIPTION
parameter clusterName - name of the Mule cluster to deploy apps

Example maven command:
mvn com.github.nicholasastuart:mule-mmc-rest-plugin:deploy -DmuleApiUrl=http://localhost:8585/mmc/api -e -Dmmc.user=admin -Dmmc.password=admin -Dmmc.serverGroup=Development -DclusterName=MuleCluster